### PR TITLE
Shows prev/next links for mobile view

### DIFF
--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,11 +1,3 @@
-<%# Link to the "First" page
-  - available local variables
-    url:           url to the first page
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
 <li class="first">
   <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, :remote => remote %>
 </li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,8 +1,1 @@
-<%# Non-link tag that stands for skipped pages...
-  - available local variables
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
 <li class="page gap"><%= t('views.pagination.truncate').html_safe %></li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,11 +1,3 @@
-<%# Link to the "Last" page
-  - available local variables
-    url:           url to the last page
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
 <li class="last">
   <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, :remote => remote %>
 </li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,11 +1,3 @@
-<%# Link to the "Next" page
-  - available local variables
-    url:           url to the next page
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<li class="next">
-  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, :rel => 'next', :remote => remote %>
+<li class="pagination-next">
+  <%= link_to_unless current_page.last?, 'Next', url, :rel => 'next', :remote => remote %>
 </li>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,14 +1,5 @@
-<%# The container tag
-  - available local variables
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
-    paginator:     the paginator that renders the pagination tags inside
--%>
 <%= paginator.render do -%>
   <ul class="pagination">
-    <%= first_page_tag unless current_page.first? %>
     <%= prev_page_tag unless current_page.first? %>
     <% each_page do |page| -%>
       <% if page.left_outer? || page.right_outer? || page.inside_window? -%>
@@ -18,6 +9,5 @@
       <% end -%>
     <% end -%>
     <%= next_page_tag unless current_page.last? %>
-    <%= last_page_tag unless current_page.last? %>
   </ul>
 <% end -%>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,11 +1,3 @@
-<%# Link to the "Previous" page
-  - available local variables
-    url:           url to the previous page
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<li class="prev">
-  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, :rel => 'prev', :remote => remote %>
+<li class="pagination-previous">
+  <%= link_to_unless current_page.first?, 'Previous', url, :rel => 'prev', :remote => remote %>
 </li>

--- a/app/views/reviewer_tweets/index.html.erb
+++ b/app/views/reviewer_tweets/index.html.erb
@@ -12,7 +12,13 @@
 <% @jsc_tweets.each do |tweet| %>
   <%= render partial: 'tweets/tweet', locals: {tweet: tweet} %>
 <% end %>
-<%= paginate @tweets %>
+
+<div class="row">
+  <div class="large-12 columns">
+    <%= paginate @tweets %>
+  </div>
+</div>
+
 
 <% if @tweets.empty? %>
   <div class="row">

--- a/app/views/tweets/index.html.erb
+++ b/app/views/tweets/index.html.erb
@@ -1,4 +1,9 @@
 <% @jsc_tweets.each do |tweet| %>
   <%= render partial: 'tweet', locals: {tweet: tweet} %>
 <% end %>
-<%= paginate @tweets %>
+
+<div class="row">
+  <div class="large-12 columns">
+    <%= paginate @tweets %>
+  </div>
+</div>


### PR DESCRIPTION
## Why

Pagination on small screens only shows the last and first link in the
pagination. With the way it's currently set up, that means the first
page and last page only.
## This change addresses the need by

Remove last and first page links so that next and previous page links
show up on small screens
## Side effects

No longer have easy access to last and first page in pagination
