### PR TITLE
Adds more visual weight to rating

### DIFF
--- a/app/assets/stylesheets/review.scss
+++ b/app/assets/stylesheets/review.scss
@@ -1,0 +1,61 @@
+@import 'variables';
+
+.review {
+  display: flex;
+  flex-direction: row;
+}
+
+.review-text-container {
+  width: 100%;
+
+  p {
+    margin: 0;
+    padding: 0;
+  }
+
+  .tweet-reply {
+    margin-top: 5px;
+    padding-top: 5px;
+    position: relative;
+    border-top: 1px dotted $color-primary-2;
+    color: #636363;
+  }
+}
+
+.review-rating {
+  background-color: #ff8841;
+  border-radius: 20px;
+  color: #fff;
+  font-size: 21px;
+  font-weight: bold;
+  height: 40px;
+  line-height: 40px;
+  text-align: center;
+  width: 40px;
+  bottom: 5px;
+  right: 15px;
+  position: absolute;
+  font-family: 'Londrina Solid', serif;
+}
+
+.no-embed {
+  .review-rating {
+    position: relative;
+    margin-left: 20px;
+    float: right;
+    margin-top: 10px;
+    bottom: 0;
+    right: 0;
+  }
+}
+
+@media only screen and (max-device-width: 500px), only screen and (max-width: 500px) {
+  .review-rating {
+    position: relative;
+    margin-left: 20px;
+    float: right;
+    margin-top: 10px;
+    bottom: 0;
+    right: 0;
+  }
+}

--- a/app/assets/stylesheets/tweets.scss
+++ b/app/assets/stylesheets/tweets.scss
@@ -35,24 +35,12 @@
   color: #636363;
 }
 
-.review-text {
-  margin-top: 5px;
-  padding-top: 5px;
-  position: relative;
-  border-top: 1px dotted $color-primary-2;
-  color: #636363;
-}
-
 .reviewed-on {
   position: absolute;
   right: 10px;
   top: 5px;
   text-align: right;
   color: $color-primary-3;
-}
-
-.review-rating {
-  margin-top: 4px;
 }
 
 @media only screen and (max-device-width: 380px), only screen and (max-width: 380px) {

--- a/app/views/tweets/_tweet.html.erb
+++ b/app/views/tweets/_tweet.html.erb
@@ -15,26 +15,33 @@
       </div>
     </div>
     <div class="row">
-      <div class="large-12 columns">
-        <div class="tweet-text">
-          <%= link_recommender(remove_hashtag_and_rating(tweet.text)).html_safe %>
+      <div class="review large-12 columns">
+        <div class="review-text-container <%= 'no-embed' unless tweet.listen_source %>">
+          <% if tweet.two_part? %>
+            <p class="tweet-text">
+              <%= link_recommender(remove_hashtag_and_rating(tweet.text)).html_safe %>
+            </p>
+            <% if tweet.rating %>
+              <div class='review-rating'>
+                <%= tweet.rating %>
+              </div>
+            <% end %>
+            <p class="tweet-reply">
+              <%= link_recommender(remove_hashtag_and_rating(tweet.review_text)).html_safe %>
+            </p>
+          <% else %>
+          <% if tweet.rating %>
+            <div class='review-rating'>
+              <%= tweet.rating %>
+            </div>
+          <% end %>
+            <p class="tweet-text">
+              <%= link_recommender(remove_hashtag_and_rating(tweet.text)).html_safe %>
+            </p>
+          <% end %>
         </div>
-        <% if tweet.two_part? %>
-          <div class="review-text">
-            <%= link_recommender(remove_hashtag_and_rating(tweet.review_text)).html_safe %>
-          </div>
-        <% end %>
       </div>
     </div>
-
-    <% if tweet.rating %>
-      <div class="review-rating row">
-        <div class="large-12 columns">
-          <strong>Rating:</strong>
-          <%= tweet.rating %>
-        </div>
-      </div>
-    <% end %>
 
     <% if tweet.listen_source %>
       <div class="row listen-embed">


### PR DESCRIPTION
Closes #14 
## Why

It's not easy to scroll through JSC reviews and pick out high/low scores for music to check out
## How this addresses the need

Floats rating to the right highlighted with site colors. Use header font to distinguish from rest of text

From this:
<img width="319" alt="screen shot 2016-07-15 at 4 59 53 pm" src="https://cloud.githubusercontent.com/assets/1896875/16888385/a427e87a-4aad-11e6-95f0-e71a5d4ce5f9.png">

To this:
<img width="625" alt="screen shot 2016-07-15 at 5 00 06 pm" src="https://cloud.githubusercontent.com/assets/1896875/16888393/a8e7c934-4aad-11e6-8213-1437f8189e65.png">
