### PR TITLE
Adds genre that is synced from sheet

### DIFF
--- a/app/assets/stylesheets/tweets.scss
+++ b/app/assets/stylesheets/tweets.scss
@@ -43,6 +43,12 @@
   color: $color-primary-3;
 }
 
+.genre {
+  margin-top: 3px;
+  margin-bottom: 3px;
+  color: $color-primary-3;
+}
+
 @media only screen and (max-device-width: 380px), only screen and (max-width: 380px) {
   .twitter-username {
     clear: left;

--- a/app/controllers/tweet_reviews_controller.rb
+++ b/app/controllers/tweet_reviews_controller.rb
@@ -44,7 +44,7 @@ class TweetReviewsController < ApplicationController
   def tweet_review_params
     params
       .require(:tweet_review)
-      .permit(:tweet_id, :twitter_status_id, :rating, :artist, :album, :listen_url)
+      .permit(:tweet_id, :twitter_status_id, :rating, :artist, :album, :listen_url, :genre)
   end
 
   def sync_tweet_review

--- a/app/presenters/july_soundcheck_tweet.rb
+++ b/app/presenters/july_soundcheck_tweet.rb
@@ -2,7 +2,7 @@ class JulySoundcheckTweet
   attr_reader :tweet, :tweet_review, :reply_tweet
 
   delegate :profile_image_uri, :text, :id, to: :tweet
-  delegate :artist, :album, :listen_url, to: :tweet_review, allow_nil: true
+  delegate :artist, :album, :listen_url, :genre, to: :tweet_review, allow_nil: true
 
   def initialize(tweet)
     @tweet = tweet

--- a/app/services/sheet_sync/downloader.rb
+++ b/app/services/sheet_sync/downloader.rb
@@ -30,7 +30,9 @@ module SheetSync
 
     def resync_review?(review_attributes)
       tweet_review = tweet_review_for(review_attributes)
-      tweet_review.nil? || tweet_review.rating.value != review_attributes[:rating]
+      tweet_review.nil? ||
+        tweet_review.rating.value != review_attributes[:rating] ||
+        tweet_review.genre.blank?
     end
 
     def tweet_review_for(review_attributes)
@@ -46,6 +48,7 @@ module SheetSync
       {
         artist: row.artist,
         album: row.album,
+        genre: row.genre,
         listen_url: parse_link(row.source(with_formula: true)),
         twitter_status_id: tweet_id,
         rating: Rating.from_score(row.rating).value,

--- a/app/services/sheet_sync/uploader.rb
+++ b/app/services/sheet_sync/uploader.rb
@@ -19,6 +19,7 @@ module SheetSync
       row.reviewer = reviewer(tweet_review) if row.reviewer.blank?
       row.date_reviewed = tweet_review.tweet.tweeted_at.strftime('%b/%e/%Y')
       row.rating = tweet_review.rating.short_description
+      row.genre = tweet_review.genre
       worksheet.save
     end
 

--- a/app/views/tweet_reviews/_form.html.erb
+++ b/app/views/tweet_reviews/_form.html.erb
@@ -41,6 +41,7 @@
       <%= f.input :rating, collection: rating_options, prompt: "Rate the album", selected: @jsc_tweet.rating.try(:value) %>
       <%= f.input :artist %>
       <%= f.input :album %>
+      <%= f.input :genre %>
       <%= hidden_field(:tweet_review, :sync, value: false) %>
       <div class="row">
         <div class="large-9 medium-9 small-7 columns">

--- a/app/views/tweets/_tweet.html.erb
+++ b/app/views/tweets/_tweet.html.erb
@@ -43,6 +43,14 @@
       </div>
     </div>
 
+    <% if tweet.genre %>
+      <div class="row genre">
+        <div class="large-12 columns">
+          <em><%= tweet.genre %></em>
+        </div>
+      </div>
+    <% end %>
+
     <% if tweet.listen_source %>
       <div class="row listen-embed">
         <div class="large-12 columns">

--- a/db/migrate/20160716034918_add_genre_to_tweet_review.rb
+++ b/db/migrate/20160716034918_add_genre_to_tweet_review.rb
@@ -1,0 +1,5 @@
+class AddGenreToTweetReview < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tweet_reviews, :genre, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160715022017) do
+ActiveRecord::Schema.define(version: 20160716034918) do
 
   create_table "tweet_reviews", force: :cascade do |t|
     t.string   "twitter_status_id"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 20160715022017) do
     t.string   "listen_url"
     t.string   "album_source_id"
     t.integer  "tweet_id"
+    t.string   "genre"
     t.index ["tweet_id"], name: "index_tweet_reviews_on_tweet_id"
   end
 


### PR DESCRIPTION
Closes #5 
## Why

The google sheet contains a genre that is not being captured in the web
app
## This change addresses the need by

Adds a column from genre on the tweet review which can be filled out in
the form when updating/creating a tweet review
