### PR TITLE
Don't overwrite attributes if blank

### DIFF
--- a/app/services/sheet_sync/downloader.rb
+++ b/app/services/sheet_sync/downloader.rb
@@ -53,7 +53,7 @@ module SheetSync
         twitter_status_id: tweet_id,
         rating: Rating.from_score(row.rating).value,
         tweet: Tweet.find_by(tweet_id: tweet_id)
-      }
+      }.keep_if { |_attr_name, attr_value| !attr_value.blank? }
     end
 
     def parse_link(cell_formula)


### PR DESCRIPTION
## Why

If a tweet review is updated on the site but isn't on the google sheet and there are blank values on sheet, the next time the site is synced the spreadsheet, updated values will be replaced by the empty cells
## How this addresses the need

Removes blank or nil attribute values so they don't overwrite an existing value
