### PR TITLE
Adds 0- and 0+ as supported ratings

### DIFF
--- a/app/value_objects/rating.rb
+++ b/app/value_objects/rating.rb
@@ -1,28 +1,32 @@
 class Rating
   SCORES = {
-    '0'  => 0,
-    '1-' => 1,
-    '1'  => 2,
-    '1+' => 3,
-    '2-' => 4,
-    '2'  => 5,
-    '2+' => 6,
-    '3-' => 7,
-    '3'  => 8,
-    '3+' => 9
+    '0-' => 0,
+    '0'  => 1,
+    '0+' => 2,
+    '1-' => 3,
+    '1'  => 4,
+    '1+' => 5,
+    '2-' => 6,
+    '2'  => 7,
+    '2+' => 8,
+    '3-' => 9,
+    '3'  => 10,
+    '3+' => 11
   }.freeze
 
   DESCRIPTIONS = {
-    0 => 'Unlistenable',
-    1 => 'Barely listenable',
-    2 => 'Only worth a listen',
-    3 => 'Probably listen only once',
-    4 => 'Probably listen more than once',
-    5 => 'Listen multiple times',
-    6 => 'Definitely listen multiple times',
-    7 => 'Almost essential',
-    8 => 'Essential',
-    9 => 'AOTM contender'
+    0  => 'Painful',
+    1  => 'Unlistenable',
+    2  => 'Almost unlistenable',
+    3  => 'Barely listenable',
+    4  => 'Only worth a listen',
+    5  => 'Probably listen only once',
+    6  => 'Probably listen more than once',
+    7  => 'Listen multiple times',
+    8  => 'Definitely listen multiple times',
+    9  => 'Almost essential',
+    10 => 'Essential',
+    11 => 'AOTM contender'
   }.freeze
 
   SCORE_GROUPS = {

--- a/db/migrate/20160718015923_adjust_for_new_zero_ratings.rb
+++ b/db/migrate/20160718015923_adjust_for_new_zero_ratings.rb
@@ -1,0 +1,19 @@
+class AdjustForNewZeroRatings < ActiveRecord::Migration[5.0]
+  class MigrateTweetReview < ActiveRecord::Base
+    self.table_name = :tweet_reviews
+  end
+
+  def up
+    MigrateTweetReview.where('rating > 0').each do |tr|
+      tr.update(rating: tr.rating + 2)
+    end
+    MigrateTweetReview.where(rating: 0).update_all(rating: 1)
+  end
+
+  def down
+    MigrateTweetReview.where('rating > 2').each do |tr|
+      tr.update(rating: tr.rating - 2)
+    end
+    MigrateTweetReview.where(rating: 1).update_all(rating: 0)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160716034918) do
+ActiveRecord::Schema.define(version: 20160718015923) do
 
   create_table "tweet_reviews", force: :cascade do |t|
     t.string   "twitter_status_id"


### PR DESCRIPTION
Closes #20 
## Why

0- and 0+ were missed when originally setting all the ratings but are
used to review JSC albums
## This change addresses the need by

Adds the two new ratings and migrates all ratings so they are adjusted
for the new slots
