### PR TITLE
Stops bug with syncing before tweet archived

### DIFF
--- a/app/services/sheet_sync/downloader.rb
+++ b/app/services/sheet_sync/downloader.rb
@@ -32,6 +32,7 @@ module SheetSync
       tweet_review = tweet_review_for(review_attributes)
       tweet_review.nil? ||
         tweet_review.rating.value != review_attributes[:rating] ||
+        tweet_review.listen_url.blank? ||
         tweet_review.genre.blank?
     end
 

--- a/lib/tasks/sync_reviews.rake
+++ b/lib/tasks/sync_reviews.rake
@@ -1,6 +1,7 @@
 namespace :reviews do
   desc "Syncs reviews with Google Sheet"
   task sync: :environment do
+    Archiver::TweetArchiver.archive
     SheetSync::Downloader.download
   end
 end


### PR DESCRIPTION
## Why

If the sheet sync is run before the tweet has been downloaded, it throws
an error expecting the tweet to exist.
## This change addresses the need by

Download all tweets before trying to sync to the sheet. Also resync if
the listen URL has been updated and is currently blank
