### PR TITLE
Check for reply tweet when syncing to sheet

### DIFF
--- a/app/services/sheet_sync/downloader.rb
+++ b/app/services/sheet_sync/downloader.rb
@@ -45,6 +45,7 @@ module SheetSync
 
     def parse_review(row)
       tweet_id = parse_tweet_id(row.tweet(with_formula: true))
+      tweet = Tweet.find_by(tweet_id: tweet_id)
       {
         artist: row.artist,
         album: row.album,
@@ -52,7 +53,7 @@ module SheetSync
         listen_url: parse_link(row.source(with_formula: true)),
         twitter_status_id: tweet_id,
         rating: Rating.from_score(row.rating).value,
-        tweet: Tweet.find_by(tweet_id: tweet_id)
+        tweet: tweet.in_reply_to_tweet || tweet
       }.keep_if { |_attr_name, attr_value| !attr_value.blank? }
     end
 


### PR DESCRIPTION
## Why

The tweet that is usually saved on the spreadsheet is the reply to the
announcement tweet. This causes the order of the tweets to be off when
the tweet review is synced since announcment tweet should be parent of
the tweet review.
## This change addresses the need by

Check to see if tweet has reply and use that for tweet review if present
