### PR TITLE
Adds user that is created from twitter user

### DIFF
--- a/app/assets/stylesheets/title_bar.scss
+++ b/app/assets/stylesheets/title_bar.scss
@@ -12,7 +12,7 @@ header {
     font-size: 32px;
     float: left;
 
-    a, a:visited, a:active {
+    a, a:visited, a:active, a:focus {
       color: #ffffff;
       transition: color 0.2s;
     }
@@ -24,14 +24,27 @@ header {
   }
 }
 
-#twitter_auth {
+.top-bar, .top-bar ul {
+  background-color: $color-primary-4;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+#title_bar_menu {
   float: right;
   margin-top: 10px;
 
-  button {
+  .is-dropdown-submenu {
+    min-width: 120px;
+    padding: 5px;
+    padding-right: 23px;
+    text-align: right;
+    background-color: $color-primary-3;
+  }
+
+  a, button {
+    color: #ffffff;
     font-weight: bold;
-    padding: 10px;
-    padding-right: 0;
   }
 }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,13 +1,18 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
+  helper_method :current_user
   helper_method :twitter_user
 
   private
 
+  def current_user
+    @current_user ||= User.find_by(twitter_id: twitter_user.id)
+  end
+
   def twitter_user
     if session['access_token'] && session['access_token_secret']
-      @user ||= Rails.cache.fetch("#{session['access_token']}:#{session['access_token_secret']}") do
+      @twitter_user ||= Rails.cache.fetch("#{session['access_token']}:#{session['access_token_secret']}") do
         twitter_client.user(include_entities: true)
       end
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,11 +3,18 @@ class SessionsController < ApplicationController
     credentials = request.env['omniauth.auth']['credentials']
     session[:access_token] = credentials['token']
     session[:access_token_secret] = credentials['secret']
+    session_creator.create
     redirect_to root_path, notice: 'Signed in'
   end
 
   def destroy
     reset_session
     redirect_to root_path, notice: 'Signed out'
+  end
+
+  private
+
+  def session_creator
+    SessionCreator.new(twitter_user)
   end
 end

--- a/app/controllers/tweet_reviews_controller.rb
+++ b/app/controllers/tweet_reviews_controller.rb
@@ -44,7 +44,9 @@ class TweetReviewsController < ApplicationController
   def tweet_review_params
     params
       .require(:tweet_review)
-      .permit(:tweet_id, :twitter_status_id, :rating, :artist, :album, :listen_url, :genre)
+      .permit(:tweet_id, :twitter_status_id, :rating, :artist, :album, :listen_url, :genre).tap do |p|
+        p[:user] = current_user
+      end
   end
 
   def sync_tweet_review

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,18 @@
+class UsersController < ApplicationController
+  before_action :set_user
+
+  def update
+    @user.update(user_params)
+    redirect_to reviewer_path(@user.twitter_screen_name)
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name)
+  end
+
+  def set_user
+    @user = User.find(current_user.id)
+  end
+end

--- a/app/form_objects/session_creator.rb
+++ b/app/form_objects/session_creator.rb
@@ -1,0 +1,17 @@
+class SessionCreator
+  attr_reader :twitter_user
+
+  def initialize(twitter_user)
+    @twitter_user = twitter_user
+  end
+
+  def create
+    user = User.find_by(twitter_id: twitter_user.id)
+    user ||= User.create(twitter_id: twitter_user.id,
+                         twitter_name: twitter_user.name,
+                         twitter_screen_name: twitter_user.screen_name)
+
+    user.update(last_sign_in: Time.current, sign_ins: user.sign_ins + 1)
+    user
+  end
+end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -1,4 +1,5 @@
 class Tweet < ApplicationRecord
+  belongs_to :user, required: false
   belongs_to :in_reply_to_tweet, class_name: 'Tweet', required: false
   has_one :reply, foreign_key: :in_reply_to_tweet_id, class_name: 'Tweet'
   has_one :tweet_review

--- a/app/models/tweet_review.rb
+++ b/app/models/tweet_review.rb
@@ -1,5 +1,6 @@
 class TweetReview < ApplicationRecord
   belongs_to :tweet
+  belongs_to :user
 
   before_save :set_album_id
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,2 @@
+class User < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,2 +1,4 @@
 class User < ApplicationRecord
+  has_many :tweets
+  has_many :tweet_reviews
 end

--- a/app/presenters/july_soundcheck_tweet.rb
+++ b/app/presenters/july_soundcheck_tweet.rb
@@ -11,7 +11,7 @@ class JulySoundcheckTweet
   end
 
   def user_name
-    tweet.name
+    tweet_review.try(:user) ? tweet_review.user.name : tweet.name
   end
 
   def screen_name

--- a/app/services/archiver/tweet_parser.rb
+++ b/app/services/archiver/tweet_parser.rb
@@ -19,7 +19,8 @@ module Archiver
         tweeted_at: tweet.created_at,
         in_reply_to_status_id: tweet.in_reply_to_status_id,
         profile_image_uri: tweet.user.profile_image_uri(:bigger),
-        in_reply_to_tweet: Tweet.find_by(tweet_id: tweet.in_reply_to_status_id)
+        in_reply_to_tweet: Tweet.find_by(tweet_id: tweet.in_reply_to_status_id),
+        user: User.find_by(twitter_id: tweet.user.id)
       }
     end
   end

--- a/app/services/sheet_sync/uploader.rb
+++ b/app/services/sheet_sync/uploader.rb
@@ -16,7 +16,7 @@ module SheetSync
       row.album = tweet_review.album
       row.source = "=HYPERLINK(\"#{tweet_review.listen_url}\",\"#{tweet_review.listen_source.source.to_s.titleize}\")"
       row.tweet = "=HYPERLINK(\"#{tweet_link(tweet_review)}\", \"#{tweet_text(tweet_review)}\")"
-      row.reviewer = reviewer(tweet_review) if row.reviewer.blank?
+      row.reviewer = reviewer(tweet_review)
       row.date_reviewed = tweet_review.tweet.tweeted_at.strftime('%b/%e/%Y')
       row.rating = tweet_review.rating.short_description
       row.genre = tweet_review.genre
@@ -37,7 +37,7 @@ module SheetSync
     end
 
     def reviewer(tweet_review)
-      tweet_review.tweet.name
+      tweet_review.user ? tweet_review.user.name : tweet_review.tweet.name
     end
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,18 +17,33 @@
 
     <header>
       <div class="row">
-        <div class="large-8 medium-10 columns">
-          <h1><a href="/">JulySoundcheck</a></h1>
-          <div id="twitter_auth">
-            <% if twitter_user %>
-              <%= form_tag '/signout', method: 'delete' do %>
-                <button  id="sign_out">Sign Out</button>
-              <% end %>
-            <% else %>
-              <%= form_tag '/auth/twitter', method: 'get' do %>
-                <button id="sign_in">Sign In</button>
-              <% end %>
-            <% end %>
+        <div class="large-8 medium-10 columns top-bar">
+          <div class="top-bar-title">
+            <h1><a href="/">JulySoundcheck</a></h1>
+          </div>
+          <div id="title_bar_menu">
+            <div class="top-bar-right">
+              <ul class="dropdown menu" data-dropdown-menu>
+                <% if twitter_user %>
+                  <li>
+                    <a href="/profile">Profile</a>
+                    <ul class="menu vertical">
+                      <li>
+                        <%= form_tag '/signout', method: 'delete' do %>
+                          <button  id="sign_out">Sign Out</button>
+                        <% end %>
+                      </li>
+                    </ul>
+                  </li>
+                <% else %>
+                  <li>
+                    <%= form_tag '/auth/twitter', method: 'get' do %>
+                      <button id="sign_in">Sign In</button>
+                    <% end %>
+                  </li>
+                <% end %>
+              </ul>
+            </div>
           </div>
         </div>
       </div>

--- a/app/views/reviewer_tweets/index.html.erb
+++ b/app/views/reviewer_tweets/index.html.erb
@@ -4,7 +4,7 @@
       @<%= @screen_name %> Tweets
     </h2>
     <div id="secondary_page_title">
-      <%= link_to 'Profile', "https://www.twitter.com/#{@screen_name}", id: 'twitter_profile_link', target: '_blank' %>
+      <%= link_to 'Twitter Profile', "https://www.twitter.com/#{@screen_name}", id: 'twitter_profile_link', target: '_blank' %>
     </div>
   </div>
 </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,15 @@
+<div  class="row">
+  <div id="page_title" class="large-12 columns">
+    <h2>Update Your Profile</h2>
+  </div>
+</div>
+
+<div class="row">
+  <div class="large-12 columns">
+    <%= simple_form_for @user do |f| %>
+      <%= f.input :name %>
+      <%= f.button :submit, "Update" %>
+      <%= link_to 'Back', root_path %>
+    <% end %>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,7 @@ module Julysoundcheck
     config.autoload_paths += %W["#{config.root}/app/value_objects"]
     config.autoload_paths += %W["#{config.root}/app/presenters"]
     config.autoload_paths += %W["#{config.root}/app/services"]
+    config.autoload_paths += %W["#{config.root}/app/form_objects"]
 
     config.before_configuration do
       env_file = File.join(Rails.root, 'config', 'local_env.yml')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,9 @@ Rails.application.routes.draw do
 
   get '/auth/twitter/callback', to: 'sessions#create', as: 'callback'
   delete '/signout', to: 'sessions#destroy', as: 'signout'
+  get '/profile', to: 'users#edit'
+
+  resources :users, only: :update
 
   resources :albums, only: :index
 

--- a/db/migrate/20160721025604_create_users.rb
+++ b/db/migrate/20160721025604_create_users.rb
@@ -1,0 +1,15 @@
+class CreateUsers < ActiveRecord::Migration[5.0]
+  def change
+    create_table :users do |t|
+      t.string   :name
+      t.string   :twitter_id
+      t.string   :twitter_name
+      t.string   :twitter_screen_name
+      t.boolean  :admin,                default: false
+      t.datetime :last_sign_in
+      t.integer  :sign_ins,             default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20160721041318_tie_tweet_review_to_user.rb
+++ b/db/migrate/20160721041318_tie_tweet_review_to_user.rb
@@ -1,0 +1,6 @@
+class TieTweetReviewToUser < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tweet_reviews, :user_id, :integer
+    add_column :tweets, :user_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160718015923) do
+ActiveRecord::Schema.define(version: 20160721025604) do
 
   create_table "tweet_reviews", force: :cascade do |t|
     t.string   "twitter_status_id"
@@ -39,6 +39,18 @@ ActiveRecord::Schema.define(version: 20160718015923) do
     t.string   "profile_image_uri"
     t.integer  "in_reply_to_tweet_id"
     t.index ["in_reply_to_tweet_id"], name: "index_tweets_on_in_reply_to_tweet_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string   "name"
+    t.string   "twitter_id"
+    t.string   "twitter_name"
+    t.string   "twitter_screen_name"
+    t.boolean  "admin",               default: false
+    t.datetime "last_sign_in"
+    t.integer  "sign_ins",            default: 0
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160721025604) do
+ActiveRecord::Schema.define(version: 20160721041318) do
 
   create_table "tweet_reviews", force: :cascade do |t|
     t.string   "twitter_status_id"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 20160721025604) do
     t.string   "album_source_id"
     t.integer  "tweet_id"
     t.string   "genre"
+    t.integer  "user_id"
     t.index ["tweet_id"], name: "index_tweet_reviews_on_tweet_id"
   end
 
@@ -38,6 +39,7 @@ ActiveRecord::Schema.define(version: 20160721025604) do
     t.string   "in_reply_to_status_id"
     t.string   "profile_image_uri"
     t.integer  "in_reply_to_tweet_id"
+    t.integer  "user_id"
     t.index ["in_reply_to_tweet_id"], name: "index_tweets_on_in_reply_to_tweet_id"
   end
 


### PR DESCRIPTION
Closes #8 
## Why

Real names are used on the JulySoundcheck spreadsheet which don't always
align to the twitter name. There needs to be a way to save the name that
is used on the spreadsheet.
## This change addresses the need by

Creates a user model that contains twitter details as well as real name.
Create profile edit page to update this real name as well as menu in top
bar to access it.
